### PR TITLE
[src] Add new methods to internally handle SOFA (right handed) into Unity (left handed) coordinate system

### DIFF
--- a/Core/Plugins/SofaUnityAPI/BaseAPI/SofaBaseMeshAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/BaseAPI/SofaBaseMeshAPI.cs
@@ -298,7 +298,7 @@ namespace SofaUnityAPI
         }
 
 
-        public int GetVertices(float[] vertices)
+        public int GetRawPositions(float[] vertices)
         {
             if (m_isReady)
             {
@@ -312,7 +312,7 @@ namespace SofaUnityAPI
             }
         }
 
-        public int GetVelocities(float[] velocities)
+        public int GetRawVelocities(float[] velocities)
         {
             if (m_isReady)
             {
@@ -326,7 +326,7 @@ namespace SofaUnityAPI
             }
         }
 
-        public int GetForces(float[] forces)
+        public int GetRawForces(float[] forces)
         {
             if (m_isReady)
             {

--- a/Core/Plugins/SofaUnityAPI/BaseAPI/SofaBaseMeshAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/BaseAPI/SofaBaseMeshAPI.cs
@@ -365,7 +365,7 @@ namespace SofaUnityAPI
 
                 for (int i = 0; i < nbrV; ++i)
                 {
-                    unityVertices[i].x = -vertices[i * 3];
+                    unityVertices[i].x = -vertices[i * 3]; // left to right coordinate system conversion
                     unityVertices[i].y = vertices[i * 3 + 1];
                     unityVertices[i].z = vertices[i * 3 + 2];
                 }
@@ -399,7 +399,7 @@ namespace SofaUnityAPI
 
             // fill triangles first
             int nbrIntTri = nbrTris * 3;
-            for (int i = 0; i < nbrTris; ++i)
+            for (int i = 0; i < nbrTris; ++i) // Triangle inversion: right to left coordinate system conversion
             {
                 trisOut[i * 3] = tris[i * 3];
                 trisOut[i * 3 + 1] = tris[i * 3 + 2];
@@ -408,15 +408,15 @@ namespace SofaUnityAPI
                 
 
             // Add quads splited as triangles
-            for (int i = 0; i < nbrQuads; ++i)
+            for (int i = 0; i < nbrQuads; ++i) // Triangle inversion: right to left coordinate system conversion
             {
                 trisOut[nbrIntTri + i * 6] = quads[i * 4];
-                trisOut[nbrIntTri + i * 6 + 1] = quads[i * 4 + 1];
-                trisOut[nbrIntTri + i * 6 + 2] = quads[i * 4 + 2];
+                trisOut[nbrIntTri + i * 6 + 1] = quads[i * 4 + 2];
+                trisOut[nbrIntTri + i * 6 + 2] = quads[i * 4 + 1];
 
                 trisOut[nbrIntTri + i * 6 + 3] = quads[i * 4];
-                trisOut[nbrIntTri + i * 6 + 4] = quads[i * 4 + 2];
-                trisOut[nbrIntTri + i * 6 + 5] = quads[i * 4 + 3];
+                trisOut[nbrIntTri + i * 6 + 4] = quads[i * 4 + 3];
+                trisOut[nbrIntTri + i * 6 + 5] = quads[i * 4 + 2];
             }
 
             // Force future deletion
@@ -475,20 +475,20 @@ namespace SofaUnityAPI
                             norms[i] = new Vector3(0, 0, 0);
                         }
 
-                        verts[i].x = -vertices[i * 3];
+                        verts[i].x = -vertices[i * 3]; // right to left coordinate system conversion
                         verts[i].y = vertices[i * 3 + 1];
                         verts[i].z = vertices[i * 3 + 2];
 
                         if (resN < 0) // no normals
                         {
                             Vector3 vec = Vector3.Normalize(verts[i]);
-                            norms[i].x = vec.x * factor;
+                            norms[i].x = - vec.x * factor; // right to left coordinate system conversion
                             norms[i].y = vec.y * factor;
                             norms[i].z = vec.z * factor;
                         }
                         else
                         {
-                            norms[i].x = -normals[i * 3] * factor;
+                            norms[i].x = -normals[i * 3] * factor; // right to left coordinate system conversion
                             norms[i].y = normals[i * 3 + 1] * factor;
                             norms[i].z = normals[i * 3 + 2] * factor;
                         }
@@ -547,7 +547,7 @@ namespace SofaUnityAPI
                         break;
                     }
 
-                    verts[id].x = -verts[id].x + timestep * velocities[i * 4 + 1];
+                    verts[id].x = -verts[id].x + timestep * velocities[i * 4 + 1]; // right to left coordinate system conversion
                     verts[id].y = verts[id].y + timestep * velocities[i * 4 + 2];
                     verts[id].z = verts[id].z + timestep * velocities[i * 4 + 3];
 
@@ -671,20 +671,20 @@ namespace SofaUnityAPI
                 {
                     for (int i = 0; i < nbrV; ++i)
                     {
-                        verts[i].x = -vertices[i * 3];
+                        verts[i].x = -vertices[i * 3]; // right to left coordinate system conversion
                         verts[i].y = vertices[i * 3 + 1];
                         verts[i].z = vertices[i * 3 + 2];
 
                         if (resN < 0) // no normals
                         {
                             Vector3 vec = Vector3.Normalize(verts[i]);
-                            norms[i].x = vec.x;// normals[i * 3];
+                            norms[i].x = -vec.x;// normals[i * 3]; // right to left coordinate system conversion
                             norms[i].y = vec.y; //normals[i * 3 + 1];
                             norms[i].z = vec.z; //normals[i * 3 + 2];
                         }
                         else
                         {
-                            norms[i].x = -normals[i * 3];
+                            norms[i].x = -normals[i * 3]; // right to left coordinate system conversion
                             norms[i].y = normals[i * 3 + 1];
                             norms[i].z = normals[i * 3 + 2];
                         }
@@ -849,7 +849,7 @@ namespace SofaUnityAPI
 
 
         /// Method to set new vertices position to this mesh
-        public void SetVertices(Vector3[] vertices, Transform sofaTransform)
+        public void SetPositions(Vector3[] vertices, Transform sofaTransform)
         {
             if (!m_isReady)
                 return;
@@ -860,7 +860,7 @@ namespace SofaUnityAPI
             for (int i = 0; i < nbrV; i++)
             {
                 Vector3 vec = sofaTransform.InverseTransformPoint(vertices[i]);
-                val[i * 3] = vec.x;
+                val[i * 3] = -vec.x; // left to right coordinate system conversion
                 val[i * 3 + 1] = vec.y;
                 val[i * 3 + 2] = vec.z;
             }
@@ -871,7 +871,7 @@ namespace SofaUnityAPI
 
         }
 
-        public void SetPositions(float[] vertices)
+        public void SetRawPositions(float[] vertices)
         {
             if (!m_isReady)
                 return;
@@ -882,7 +882,7 @@ namespace SofaUnityAPI
 
         }
 
-        public void SetVelocities(float[] values)
+        public void SetRawVelocities(float[] values)
         {
             if (!m_isReady)
                 return;
@@ -895,7 +895,7 @@ namespace SofaUnityAPI
 
 
         /// Method to set new vertices position to this mesh
-        public void SetRestPositions(float[] vertices)
+        public void SetRawRestPositions(float[] vertices)
         {
             if (!m_isReady)
                 return;
@@ -928,7 +928,7 @@ namespace SofaUnityAPI
 
             for (int i = 0; i < nbrV; i++)
             {
-                val[i * 3] = vels[i].x;
+                val[i * 3] = -vels[i].x; // left to right coordinate system conversion
                 val[i * 3 + 1] = vels[i].y;
                 val[i * 3 + 2] = vels[i].z;
             }
@@ -946,7 +946,7 @@ namespace SofaUnityAPI
                 return;
 
             float[] val = new float[3];
-            val[0] = value[0];
+            val[0] = -value[0]; // left to right coordinate system conversion
             val[1] = value[1];
             val[2] = value[2];
             int resUpdate = sofaMeshAPI_setVertices(m_simu, m_name, val);

--- a/Core/Plugins/SofaUnityAPI/BaseAPI/SofaBaseMeshAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/BaseAPI/SofaBaseMeshAPI.cs
@@ -365,7 +365,7 @@ namespace SofaUnityAPI
 
                 for (int i = 0; i < nbrV; ++i)
                 {
-                    unityVertices[i].x = vertices[i * 3];
+                    unityVertices[i].x = -vertices[i * 3];
                     unityVertices[i].y = vertices[i * 3 + 1];
                     unityVertices[i].z = vertices[i * 3 + 2];
                 }
@@ -399,8 +399,13 @@ namespace SofaUnityAPI
 
             // fill triangles first
             int nbrIntTri = nbrTris * 3;
-            for (int i = 0; i < nbrIntTri; ++i)
-                trisOut[i] = tris[i];
+            for (int i = 0; i < nbrTris; ++i)
+            {
+                trisOut[i * 3] = tris[i * 3];
+                trisOut[i * 3 + 1] = tris[i * 3 + 2];
+                trisOut[i * 3 + 2] = tris[i * 3 + 1];
+            }
+                
 
             // Add quads splited as triangles
             for (int i = 0; i < nbrQuads; ++i)
@@ -470,7 +475,7 @@ namespace SofaUnityAPI
                             norms[i] = new Vector3(0, 0, 0);
                         }
 
-                        verts[i].x = vertices[i * 3];
+                        verts[i].x = -vertices[i * 3];
                         verts[i].y = vertices[i * 3 + 1];
                         verts[i].z = vertices[i * 3 + 2];
 
@@ -483,7 +488,7 @@ namespace SofaUnityAPI
                         }
                         else
                         {
-                            norms[i].x = normals[i * 3] * factor;
+                            norms[i].x = -normals[i * 3] * factor;
                             norms[i].y = normals[i * 3 + 1] * factor;
                             norms[i].z = normals[i * 3 + 2] * factor;
                         }
@@ -542,7 +547,7 @@ namespace SofaUnityAPI
                         break;
                     }
 
-                    verts[id].x = verts[id].x + timestep * velocities[i * 4 + 1];
+                    verts[id].x = -verts[id].x + timestep * velocities[i * 4 + 1];
                     verts[id].y = verts[id].y + timestep * velocities[i * 4 + 2];
                     verts[id].z = verts[id].z + timestep * velocities[i * 4 + 3];
 
@@ -666,7 +671,7 @@ namespace SofaUnityAPI
                 {
                     for (int i = 0; i < nbrV; ++i)
                     {
-                        verts[i].x = vertices[i * 3];
+                        verts[i].x = -vertices[i * 3];
                         verts[i].y = vertices[i * 3 + 1];
                         verts[i].z = vertices[i * 3 + 2];
 
@@ -679,7 +684,7 @@ namespace SofaUnityAPI
                         }
                         else
                         {
-                            norms[i].x = normals[i * 3];
+                            norms[i].x = -normals[i * 3];
                             norms[i].y = normals[i * 3 + 1];
                             norms[i].z = normals[i * 3 + 2];
                         }

--- a/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
@@ -315,8 +315,10 @@ namespace SofaUnityAPI
         public void setGravity(Vector3 gravity)
         {
             double[] grav = new double[3];
-            for (int i = 0; i < 3; ++i)
-                grav[i] = (double)gravity[i];
+            // left to right coordinate system conversion
+            grav[0] = -gravity.x;
+            grav[1] = gravity.y;
+            grav[2] = gravity.z;
 
             if (m_isReady)
                 sofaPhysicsAPI_setGravity(m_native, grav);
@@ -332,8 +334,10 @@ namespace SofaUnityAPI
 
                 if (res == 0)
                 {
-                    for (int i = 0; i < 3; ++i)
-                        gravity[i] = (float)grav[i];
+                    // right to left coordinate system conversion
+                    gravity[0] = (float)(-grav[0]);
+                    gravity[1] = (float)grav[1];
+                    gravity[2] = (float)grav[2];
                 }
                 else
                     Debug.LogError("SofaContextAPI::getGravity method returns: " + SofaDefines.msg_error[res]);

--- a/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
@@ -236,7 +236,7 @@ namespace SofaUnityAPI
             if (m_isReady)
             {
                 int res = sofaPhysicsAPI_loadPlugin(m_native, pluginName);
-                if (res < 0)
+                if (res != 0)
                     Debug.LogError("SofaContextAPI::loadPlugin: " + pluginName + ", method returns: " + SofaDefines.msg_error[res]);
             }
             else

--- a/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
@@ -236,7 +236,7 @@ namespace SofaUnityAPI
             if (m_isReady)
             {
                 int res = sofaPhysicsAPI_loadPlugin(m_native, pluginName);
-                if (res != 0)
+                if (res < 0)
                     Debug.LogError("SofaContextAPI::loadPlugin: " + pluginName + ", method returns: " + SofaDefines.msg_error[res]);
             }
             else

--- a/Core/Plugins/SofaUnityAPI/SofaCustomMeshAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/SofaCustomMeshAPI.cs
@@ -91,7 +91,7 @@ namespace SofaUnityAPI
                 Vector3 vert = trans.TransformPoint(vertices[i]);
                 Vector3 vertS = sofaCTransform.InverseTransformPoint(vert);
 
-                val[i * 3] = vertS.x;
+                val[i * 3] = -vertS.x; // left to right coordinate system conversion
                 val[i * 3 + 1] = vertS.y;
                 val[i * 3 + 2] = vertS.z;
             }

--- a/Core/Plugins/SofaUnityAPI/ToolsAPI/SofaRayCasterAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/ToolsAPI/SofaRayCasterAPI.cs
@@ -93,11 +93,14 @@ namespace SofaUnityAPI
             float[] ori = new float[3];
             float[] dir = new float[3];
 
-            for (int i = 0; i < 3; ++i)
-            {
-                ori[i] = originInSofa[i];
-                dir[i] = directionInSofa[i];
-            }
+            // left to right coordinate system conversion
+            ori[0] = -originInSofa[0];
+            ori[1] = originInSofa[1];
+            ori[2] = originInSofa[2];
+
+            dir[0] = -directionInSofa[0];
+            dir[1] = directionInSofa[1];
+            dir[2] = directionInSofa[2];
 
             int res = sofaPhysicsAPI_castRay(m_simu, m_name, ori, dir);
 

--- a/Core/Scripts/Core/Components/SofaCollisionModel.cs
+++ b/Core/Scripts/Core/Components/SofaCollisionModel.cs
@@ -193,8 +193,6 @@ namespace SofaUnity
             int nbrSpheres = m_sofaMesh.NbVertices();
             m_collisionElement = new List<GameObject>();
 
-            float[] vertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
-
             // get sphere radius
             float radius = 1.0f;
             if (fixedRadius == 0.0f)
@@ -218,7 +216,7 @@ namespace SofaUnity
             {
                 GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 sphere.name = "SphereCollision_" + i;
-                sphere.transform.localPosition = new Vector3(-vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
+                sphere.transform.localPosition = m_sofaMesh.GetPosition(i);
                 sphere.transform.localScale = scaleRadius;
                 sphere.transform.parent = this.transform;
                 m_collisionElement.Add(sphere);
@@ -297,11 +295,10 @@ namespace SofaUnity
             if (this.m_componentType == "SphereCollisionModel" || this.m_componentType == "PointCollisionModel")
             {
                 int nbrSpheres = m_collisionElement.Count;
-                float[] vertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
                 for (int i = 0; i < nbrSpheres; i++)
                 {
                     GameObject sphere = m_collisionElement[i];
-                    sphere.transform.localPosition = new Vector3(-vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
+                    sphere.transform.localPosition = m_sofaMesh.GetPosition(i);
                 }
             }
             else if (this.m_componentType == "TriangleCollisionModel")

--- a/Core/Scripts/Core/Components/SofaCollisionModel.cs
+++ b/Core/Scripts/Core/Components/SofaCollisionModel.cs
@@ -218,7 +218,7 @@ namespace SofaUnity
             {
                 GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 sphere.name = "SphereCollision_" + i;
-                sphere.transform.localPosition = new Vector3(vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
+                sphere.transform.localPosition = new Vector3(-vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
                 sphere.transform.localScale = scaleRadius;
                 sphere.transform.parent = this.transform;
                 m_collisionElement.Add(sphere);
@@ -301,7 +301,7 @@ namespace SofaUnity
                 for (int i = 0; i < nbrSpheres; i++)
                 {
                     GameObject sphere = m_collisionElement[i];
-                    sphere.transform.localPosition = new Vector3(vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
+                    sphere.transform.localPosition = new Vector3(-vertices[i * 3], vertices[i * 3 + 1], vertices[i * 3 + 2]);
                 }
             }
             else if (this.m_componentType == "TriangleCollisionModel")

--- a/Core/Scripts/Core/Components/SofaFEMForceField.cs
+++ b/Core/Scripts/Core/Components/SofaFEMForceField.cs
@@ -103,7 +103,8 @@ namespace SofaUnity
 
                     //Only do this in the editor
                     MeshFilter mf = GetComponent<MeshFilter>();
-                    mf.mesh = m_sofaMesh.SofaMeshTopology.m_mesh;
+                    if (m_sofaMesh.HasTopology())
+                        mf.mesh = m_sofaMesh.SofaMeshTopology.m_mesh;
                     m_trackedTopologyRevision = m_sofaMesh.GetTopologyRevision();
                 }
             }

--- a/Core/Scripts/Core/Components/SofaMesh.cs
+++ b/Core/Scripts/Core/Components/SofaMesh.cs
@@ -126,10 +126,10 @@ namespace SofaUnity
         }
 
         /// Method to set new vertices position to this mesh
-        public void SetVertices(Vector3[] vertices)
+        public void SetPositions(Vector3[] vertices)
         {
             if (m_sofaMeshAPI != null)
-                m_sofaMeshAPI.SetVertices(vertices, m_sofaContext.transform);
+                m_sofaMeshAPI.SetPositions(vertices, m_sofaContext.transform);
         }
 
         /// Method to set new vertices velocity to this mesh
@@ -139,24 +139,28 @@ namespace SofaUnity
                 m_sofaMeshAPI.SetVelocities(vels);
         }
 
-        public void SetPositions(float[] vertices)
+        /// Method to set new vertices position to this mesh, using raw float buffer. 
+        /// !! Be careful, no conversion from left-right coordinates system
+        public void SetRawPositions(float[] vertices)
         {
             if (m_sofaMeshAPI != null)
-                m_sofaMeshAPI.SetPositions(vertices);
+                m_sofaMeshAPI.SetRawPositions(vertices);
         }
 
-        public void SetVelocities(float[] vels)
+        /// Method to set new vertices velocity to this mesh, using raw float buffer. 
+        /// !! Be careful, no conversion from left-right coordinates system
+        public void SetRawVelocities(float[] vels)
         {
             if (m_sofaMeshAPI != null)
-                m_sofaMeshAPI.SetVelocities(vels);
+                m_sofaMeshAPI.SetRawVelocities(vels);
         }
 
 
         /// Method to set new vertices position to this mesh
-        public void SetRestPositions(float[] vertices)
+        public void SetRawRestPositions(float[] vertices)
         {
             if (m_sofaMeshAPI != null)
-                m_sofaMeshAPI.SetRestPositions(vertices);
+                m_sofaMeshAPI.SetRawRestPositions(vertices);
         }
 
 

--- a/Core/Scripts/Core/Components/SofaMesh.cs
+++ b/Core/Scripts/Core/Components/SofaMesh.cs
@@ -358,13 +358,12 @@ namespace SofaUnity
             m_unityVertices = new Vector3[m_nbVertices];
             for (int i = 0; i < m_nbVertices; ++i)
             {
-                m_unityVertices[i].x = -m_vertexBuffer[i * m_meshDim];
-                m_unityVertices[i].y = m_vertexBuffer[i * m_meshDim + 1];
-
                 if (m_meshDim > 2)
-                    m_unityVertices[i].z = m_vertexBuffer[i * m_meshDim + 2];
+                    m_unityVertices[i] = new Vector3(-m_vertexBuffer[i * m_meshDim], m_vertexBuffer[i * m_meshDim + 1], m_vertexBuffer[i * m_meshDim + 2]);
+                else if (m_meshDim > 1)
+                    m_unityVertices[i] = new Vector3(-m_vertexBuffer[i * m_meshDim], m_vertexBuffer[i * m_meshDim + 1], 0.0f);
                 else
-                    m_unityVertices[i].z = 0.0f;
+                    m_unityVertices[i] = new Vector3(-m_vertexBuffer[i * m_meshDim], 0.0f, 0.0f);
             }
         }
 
@@ -410,7 +409,7 @@ namespace SofaUnity
             }
             else if (this.TopologyType() == TopologyObjectType.EDGE)
             {
-                m_sofaMeshAPI.GetRawPositions(m_vertexBuffer);
+                m_sofaMeshAPI.updateMesh(m_topology.m_mesh);
             }
             else if (this.TopologyType() == TopologyObjectType.HEXAHEDRON)
             {
@@ -423,6 +422,13 @@ namespace SofaUnity
             }
             else if (this.TopologyType() == TopologyObjectType.NO_TOPOLOGY)
             {
+                int _nbV = m_sofaMeshAPI.getNbVertices();
+                if (m_nbVertices != _nbV)
+                {
+                    m_nbVertices = _nbV;
+                    m_unityVertices = new Vector3[m_nbVertices];
+                }
+
                 m_sofaMeshAPI.updateVertices(m_unityVertices);
             }
 

--- a/Core/Scripts/Core/Components/SofaVisualModel.cs
+++ b/Core/Scripts/Core/Components/SofaVisualModel.cs
@@ -148,7 +148,6 @@ namespace SofaUnity
                 //if (res == -1)
                 //    m_sofaContext.breakerProcedure();
                 m_sofaMeshAPI.updateMesh(m_mesh);
-                //m_mesh.RecalculateNormals();
             }
             m_mesh.RecalculateBounds();
         }

--- a/Core/Scripts/Core/Components/SofaVisualModel.cs
+++ b/Core/Scripts/Core/Components/SofaVisualModel.cs
@@ -148,6 +148,7 @@ namespace SofaUnity
                 //if (res == -1)
                 //    m_sofaContext.breakerProcedure();
                 m_sofaMeshAPI.updateMesh(m_mesh);
+                //m_mesh.RecalculateNormals();
             }
             m_mesh.RecalculateBounds();
         }

--- a/Core/Scripts/Core/Topology/SofaMeshTopology.cs
+++ b/Core/Scripts/Core/Topology/SofaMeshTopology.cs
@@ -1,4 +1,3 @@
-﻿using SofaUnityAPI;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;

--- a/Core/Scripts/Core/Topology/SofaMeshTopology.cs
+++ b/Core/Scripts/Core/Topology/SofaMeshTopology.cs
@@ -34,7 +34,7 @@ namespace SofaUnity
         /// number of points inside this mesh
         public int m_meshDim = 3;
 
-        /// real buffer sent to SOFA
+        /// real buffer sent to SOFA (right handed)
         public float[] m_vertexBuffer = null;
         public float[] m_restVertexBuffer = null;
 
@@ -238,7 +238,7 @@ namespace SofaUnity
             Vector3[] unityVertices = new Vector3[m_nbVertices];
             for (int i = 0; i < m_nbVertices; ++i)
             {
-                unityVertices[i].x = m_vertexBuffer[i * 3];
+                unityVertices[i].x = -m_vertexBuffer[i * 3];
                 unityVertices[i].y = m_vertexBuffer[i * 3 + 1];
                 unityVertices[i].z = m_vertexBuffer[i * 3 + 2];
             }
@@ -255,7 +255,7 @@ namespace SofaUnity
             Vector3[] unityVertices = new Vector3[m_nbVertices];
             for (int i = 0; i < m_nbVertices; ++i)
             {
-                unityVertices[i].x = m_vertexBuffer[i * 2];
+                unityVertices[i].x = -m_vertexBuffer[i * 2];
                 unityVertices[i].y = m_vertexBuffer[i * 2 + 1];
                 unityVertices[i].z = 0.0f;
             }

--- a/Core/Scripts/Core/Topology/SofaMeshTopology.cs
+++ b/Core/Scripts/Core/Topology/SofaMeshTopology.cs
@@ -16,13 +16,12 @@ namespace SofaUnity
         ////////////////////////////////////////////
 
         /// Higher level of topology handle in this class
-        protected TopologyObjectType m_topologyType = TopologyObjectType.NO_TOPOLOGY;
+        protected TopologyObjectType m_topologyType = TopologyObjectType.UNKNOWN;
 
         /// Pointer to the Unity Mesh structure
         public Mesh m_mesh = null;
 
         // Do we need dynamic or static buffer here??
-        protected List<Vector3> m_vertices = null;
         protected List<Edge> m_edges = null;
         protected List<Triangle> m_triangles = null;
         protected List<Quad> m_quads = null;
@@ -205,6 +204,11 @@ namespace SofaUnity
             else if (m_topologyType == TopologyObjectType.EDGE)
             {
                 ComputeMeshFromEdge();
+            }
+            else // means no topology
+            {
+                m_topologyType = TopologyObjectType.NO_TOPOLOGY;
+                Debug.LogError("No mesh can be created as this object has no topology.");
             }
         }
 

--- a/Core/Scripts/Core/Topology/SofaMeshTopology.cs
+++ b/Core/Scripts/Core/Topology/SofaMeshTopology.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using SofaUnityAPI;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -33,10 +34,6 @@ namespace SofaUnity
         protected int m_nbVertices = 0;
         /// number of points inside this mesh
         public int m_meshDim = 3;
-
-        /// real buffer sent to SOFA (right handed)
-        public float[] m_vertexBuffer = null;
-        public float[] m_restVertexBuffer = null;
 
         /// number of triangles inside this mesh
         protected int nbTriangles = 0;
@@ -166,38 +163,20 @@ namespace SofaUnity
             m_topologyType = TopologyObjectType.EDGE;
         }
 
-
-        /// Method to create a vertex static float buffer given the number of vertices
-        public void CreateVertexBuffer(int nbVertices, int meshDimension)
-        {
-            m_nbVertices = nbVertices;
-            m_meshDim = meshDimension;
-            m_vertexBuffer = new float[nbVertices * m_meshDim];
-        }
-
-        public void CreateRestVertexBuffer()
-        {
-            int nbrFloat = m_nbVertices * m_meshDim;
-            m_restVertexBuffer = new float[nbrFloat];
-
-            for (int i=0; i< nbrFloat; i++)
-            {
-                m_restVertexBuffer[i] = m_vertexBuffer[i];
-            }
-        }
-
         
         /// Main method to compute the mesh given its topology type and static buffer. Will call internal method according to the type.
-        public void ComputeMesh()
+        public void ComputeMesh(float[] sofaVertices, int nbVertices, int meshDim)
         {
+            m_nbVertices = nbVertices;
+
             // compute mesh in fonction of its dimension
-            if (m_meshDim == 3)
+            if (meshDim == 3)
             {
-                Compute3DMesh();
+                Compute3DMesh(sofaVertices);
             }
-            else if (m_meshDim == 2)
+            else if (meshDim == 2)
             {
-                Compute2DMesh();
+                Compute2DMesh(sofaVertices);
             }
             else
             {
@@ -231,16 +210,16 @@ namespace SofaUnity
         }
 
 
-        protected void Compute3DMesh()
+        protected void Compute3DMesh(float[] sofaVertices)
         {
             m_mesh = new Mesh();
             m_mesh.name = "SofaMesh";
             Vector3[] unityVertices = new Vector3[m_nbVertices];
             for (int i = 0; i < m_nbVertices; ++i)
             {
-                unityVertices[i].x = -m_vertexBuffer[i * 3];
-                unityVertices[i].y = m_vertexBuffer[i * 3 + 1];
-                unityVertices[i].z = m_vertexBuffer[i * 3 + 2];
+                unityVertices[i].x = -sofaVertices[i * 3];
+                unityVertices[i].y = sofaVertices[i * 3 + 1];
+                unityVertices[i].z = sofaVertices[i * 3 + 2];
             }
             m_mesh.vertices = unityVertices;
             m_mesh.normals = new Vector3[m_nbVertices];
@@ -248,21 +227,22 @@ namespace SofaUnity
         }
 
 
-        protected void Compute2DMesh()
+        protected void Compute2DMesh(float[] sofaVertices)
         {
             m_mesh = new Mesh();
             m_mesh.name = "SofaMesh";
             Vector3[] unityVertices = new Vector3[m_nbVertices];
             for (int i = 0; i < m_nbVertices; ++i)
             {
-                unityVertices[i].x = -m_vertexBuffer[i * 2];
-                unityVertices[i].y = m_vertexBuffer[i * 2 + 1];
+                unityVertices[i].x = -sofaVertices[i * 2];
+                unityVertices[i].y = sofaVertices[i * 2 + 1];
                 unityVertices[i].z = 0.0f;
             }
             m_mesh.vertices = unityVertices;
             m_mesh.normals = new Vector3[m_nbVertices];
             m_mesh.uv = new Vector2[m_nbVertices];
         }
+
 
 
         ////////////////////////////////////////////

--- a/Core/Scripts/Core/Topology/SofaMeshTopology.cs
+++ b/Core/Scripts/Core/Topology/SofaMeshTopology.cs
@@ -286,57 +286,57 @@ namespace SofaUnity
                 // face back
                 int triVId = i * 12 * 3;
                 tris[triVId + 0] = id[0];
-                tris[triVId + 1] = id[2];
-                tris[triVId + 2] = id[1];
+                tris[triVId + 1] = id[1];
+                tris[triVId + 2] = id[2];
 
                 tris[triVId + 3] = id[0];
-                tris[triVId + 4] = id[3];
-                tris[triVId + 5] = id[2];
+                tris[triVId + 4] = id[2];
+                tris[triVId + 5] = id[3];
 
                 // face front
                 tris[triVId + 6] = id[4];
-                tris[triVId + 7] = id[5];
-                tris[triVId + 8] = id[6];
+                tris[triVId + 7] = id[6];
+                tris[triVId + 8] = id[5];
 
                 tris[triVId + 9] = id[4];
-                tris[triVId + 10] = id[6];
-                tris[triVId + 11] = id[7];
+                tris[triVId + 10] = id[7];
+                tris[triVId + 11] = id[6];
 
                 // face right
                 tris[triVId + 12] = id[1];
-                tris[triVId + 13] = id[2];
-                tris[triVId + 14] = id[6];
+                tris[triVId + 13] = id[6];
+                tris[triVId + 14] = id[2];
 
                 tris[triVId + 15] = id[5];
-                tris[triVId + 16] = id[1];
-                tris[triVId + 17] = id[6];
+                tris[triVId + 16] = id[6];
+                tris[triVId + 17] = id[1];
 
                 // face left
                 tris[triVId + 18] = id[0];
-                tris[triVId + 19] = id[7];
-                tris[triVId + 20] = id[3];
+                tris[triVId + 19] = id[3];
+                tris[triVId + 20] = id[7];
 
                 tris[triVId + 21] = id[0];
-                tris[triVId + 22] = id[4];
-                tris[triVId + 23] = id[7];
+                tris[triVId + 22] = id[7];
+                tris[triVId + 23] = id[4];
 
                 // face up
                 tris[triVId + 24] = id[2];
-                tris[triVId + 25] = id[3];
-                tris[triVId + 26] = id[6];
+                tris[triVId + 25] = id[6];
+                tris[triVId + 26] = id[3];
 
                 tris[triVId + 27] = id[3];
-                tris[triVId + 28] = id[7];
-                tris[triVId + 29] = id[6];
+                tris[triVId + 28] = id[6];
+                tris[triVId + 29] = id[7];
 
                 // face down
                 tris[triVId + 30] = id[0];
-                tris[triVId + 31] = id[1];
-                tris[triVId + 32] = id[5];
+                tris[triVId + 31] = id[5];
+                tris[triVId + 32] = id[1];
 
                 tris[triVId + 33] = id[0];
-                tris[triVId + 34] = id[5];
-                tris[triVId + 35] = id[4];
+                tris[triVId + 34] = id[4];
+                tris[triVId + 35] = id[5];
             }
 
             m_mesh.vertices = verts;
@@ -380,23 +380,23 @@ namespace SofaUnity
 
                 // face 0
                 tris[i * 12 + 0] = id[0];
-                tris[i * 12 + 1] = id[2];
-                tris[i * 12 + 2] = id[1];
+                tris[i * 12 + 1] = id[1];
+                tris[i * 12 + 2] = id[2];
 
                 // face 1
                 tris[i * 12 + 3] = id[1];
-                tris[i * 12 + 4] = id[2];
-                tris[i * 12 + 5] = id[3];
+                tris[i * 12 + 4] = id[3];
+                tris[i * 12 + 5] = id[2];
 
                 // face 2
                 tris[i * 12 + 6] = id[2];
-                tris[i * 12 + 7] = id[0];
-                tris[i * 12 + 8] = id[3];
+                tris[i * 12 + 7] = id[3];
+                tris[i * 12 + 8] = id[0];
 
                 // face 3
                 tris[i * 12 + 9] = id[0];
-                tris[i * 12 + 10] = id[1];
-                tris[i * 12 + 11] = id[3];
+                tris[i * 12 + 10] = id[3];
+                tris[i * 12 + 11] = id[1];
             }
 
             m_mesh.vertices = verts;

--- a/Core/Scripts/Core/Topology/TopologyElements.cs
+++ b/Core/Scripts/Core/Topology/TopologyElements.cs
@@ -17,7 +17,8 @@ namespace SofaUnity
         QUAD,
         TETRAHEDRON,
         HEXAHEDRON,
-        NO_TOPOLOGY
+        NO_TOPOLOGY,
+        UNKNOWN
     };
 
 

--- a/Core/Scripts/Editor/Components/SofaMeshEditor.cs
+++ b/Core/Scripts/Editor/Components/SofaMeshEditor.cs
@@ -19,7 +19,8 @@ namespace SofaUnity
             base.OnInspectorGUI();
 
             SofaMesh compo = (SofaMesh)this.target;
-            compo.DrawForces = EditorGUILayout.Toggle("DrawGizmoForces", compo.DrawForces);
+
+            EditorGUILayout.IntField("Nb Points", compo.NbVertices());
 
             if (!compo.HasTopology())
                 return;
@@ -47,11 +48,8 @@ namespace SofaUnity
             {
                 EditorGUILayout.IntField("Nb Edges", compo.NbEdges());
             }
-            else
-            {
-                EditorGUILayout.IntField("Nb Points", compo.NbVertices());
-            }
 
+            compo.DrawForces = EditorGUILayout.Toggle("DrawGizmoForces", compo.DrawForces);
 
             EditorGUI.EndDisabledGroup();
         }

--- a/Core/Scripts/Modules/Components/SofaBeamAdapterModel.cs
+++ b/Core/Scripts/Modules/Components/SofaBeamAdapterModel.cs
@@ -94,7 +94,7 @@ namespace SofaUnity
             float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
             for (int i = 0; i < nbrV; i++)
             {
-                m_vertCenter[nbrV - i - 1] = new Vector3(sofaVertices[i * 3], sofaVertices[i * 3 + 1], sofaVertices[i * 3 + 2]);
+                m_vertCenter[nbrV - i - 1] = new Vector3(-sofaVertices[i * 3], sofaVertices[i * 3 + 1], sofaVertices[i * 3 + 2]);
             }
 
             // update position vectors for camera

--- a/Core/Scripts/Modules/Components/SofaBeamAdapterModel.cs
+++ b/Core/Scripts/Modules/Components/SofaBeamAdapterModel.cs
@@ -91,10 +91,9 @@ namespace SofaUnity
                 return;
 
             //Debug.Log("BeamModel::UpdateLinearMesh");            
-            float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
             for (int i = 0; i < nbrV; i++)
             {
-                m_vertCenter[nbrV - i - 1] = new Vector3(-sofaVertices[i * 3], sofaVertices[i * 3 + 1], sofaVertices[i * 3 + 2]);
+                m_vertCenter[nbrV - i - 1] = m_sofaMesh.SofaMeshTopology.m_mesh.vertices[i];
             }
 
             // update position vectors for camera

--- a/Core/Scripts/Modules/Components/SofaBeamModel.cs
+++ b/Core/Scripts/Modules/Components/SofaBeamModel.cs
@@ -166,7 +166,7 @@ namespace SofaUnity
 
             for (int i = 0; i < nbrV; i++)
             {
-                m_vertCenter[i] = new Vector3(sofaVertices[i * sizeDof], sofaVertices[i * sizeDof + 1], sofaVertices[i * sizeDof + 2]);
+                m_vertCenter[i] = new Vector3(-sofaVertices[i * sizeDof], sofaVertices[i * sizeDof + 1], sofaVertices[i * sizeDof + 2]);
             }
 
             int nbrPointPerCircle = 4 * m_beamDiscretisation + 1; // +1 to close cylinder UV
@@ -306,7 +306,7 @@ namespace SofaUnity
             float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
             for (int i = 0; i < nbrV; i++)
             {
-                m_vertCenter[i] = new Vector3(sofaVertices[i * sizeDof], sofaVertices[i * sizeDof + 1], sofaVertices[i * sizeDof + 2]);
+                m_vertCenter[i] = new Vector3(-sofaVertices[i * sizeDof], sofaVertices[i * sizeDof + 1], sofaVertices[i * sizeDof + 2]);
             }
 
 

--- a/Core/Scripts/Modules/Components/SofaBeamModel.cs
+++ b/Core/Scripts/Modules/Components/SofaBeamModel.cs
@@ -157,7 +157,6 @@ namespace SofaUnity
                 return;
 
             m_mesh.Clear();
-            float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
             m_vertCenter = new Vector3[nbrV];
 
             int sizeDof = 3;
@@ -166,7 +165,7 @@ namespace SofaUnity
 
             for (int i = 0; i < nbrV; i++)
             {
-                m_vertCenter[i] = new Vector3(-sofaVertices[i * sizeDof], sofaVertices[i * sizeDof + 1], sofaVertices[i * sizeDof + 2]);
+                m_vertCenter[i] = m_sofaMesh.GetPosition(i);
             }
 
             int nbrPointPerCircle = 4 * m_beamDiscretisation + 1; // +1 to close cylinder UV
@@ -303,10 +302,9 @@ namespace SofaUnity
             if (isRigidMesh)
                 sizeDof = 7;
 
-            float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
             for (int i = 0; i < nbrV; i++)
             {
-                m_vertCenter[i] = new Vector3(-sofaVertices[i * sizeDof], sofaVertices[i * sizeDof + 1], sofaVertices[i * sizeDof + 2]);
+                m_vertCenter[i] = m_sofaMesh.GetPosition(i);
             }
 
 

--- a/Core/Scripts/Modules/Components/SofaParticlesModel.cs
+++ b/Core/Scripts/Modules/Components/SofaParticlesModel.cs
@@ -116,7 +116,7 @@ namespace SofaUnity
             for (int i = 0; i < nbrV; ++i)
             {
                 //ParticleSystem.Particle part = m_particles[i];
-                m_particles[i].position = m_sofaMesh.SofaMeshTopology.m_mesh.vertices[i];
+                m_particles[i].position = m_sofaMesh.GetPosition(i);
                 m_particles[i].startSize = m_particleSize;
                 //m_particles[i].remainingLifetime = 1000.0f;
                 //part.remainingLifetime = 10000.0f;

--- a/Core/Scripts/Modules/Components/SofaParticlesModel.cs
+++ b/Core/Scripts/Modules/Components/SofaParticlesModel.cs
@@ -117,7 +117,7 @@ namespace SofaUnity
             for (int i = 0; i < nbrV; ++i)
             {
                 //ParticleSystem.Particle part = m_particles[i];
-                m_particles[i].position = new Vector3(sofaVertices[i * 3], sofaVertices[i * 3 + 1], sofaVertices[i * 3 + 2]);
+                m_particles[i].position = new Vector3(-sofaVertices[i * 3], sofaVertices[i * 3 + 1], sofaVertices[i * 3 + 2]);
                 m_particles[i].startSize = m_particleSize;
                 //m_particles[i].remainingLifetime = 1000.0f;
                 //part.remainingLifetime = 10000.0f;

--- a/Core/Scripts/Modules/Components/SofaParticlesModel.cs
+++ b/Core/Scripts/Modules/Components/SofaParticlesModel.cs
@@ -113,11 +113,10 @@ namespace SofaUnity
             //Debug.Log(Time.fixedTime + " - m_pSystem.particleCount: " + m_pSystem.particleCount + " | m_particles: " + m_particles.Length);
 
             // 2. Update particles
-            float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
             for (int i = 0; i < nbrV; ++i)
             {
                 //ParticleSystem.Particle part = m_particles[i];
-                m_particles[i].position = new Vector3(-sofaVertices[i * 3], sofaVertices[i * 3 + 1], sofaVertices[i * 3 + 2]);
+                m_particles[i].position = m_sofaMesh.SofaMeshTopology.m_mesh.vertices[i];
                 m_particles[i].startSize = m_particleSize;
                 //m_particles[i].remainingLifetime = 1000.0f;
                 //part.remainingLifetime = 10000.0f;

--- a/Core/Scripts/Modules/Controllers/SofaCapsuleController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaCapsuleController.cs
@@ -117,14 +117,14 @@ namespace SofaUnity
         {
             newPosition[0] = capsuleOri - this.transform.up * m_speed;
             m_sofaCapsuleMesh.SetVelocities(stopVelocity);
-            m_sofaCapsuleMesh.SetVertices(newPosition);
+            m_sofaCapsuleMesh.SetPositions(newPosition);
         }
 
         protected void MoveBackward()
         {
             newPosition[0] = capsuleOri + this.transform.up * m_speed;
             m_sofaCapsuleMesh.SetVelocities(stopVelocity);
-            m_sofaCapsuleMesh.SetVertices(newPosition);
+            m_sofaCapsuleMesh.SetPositions(newPosition);
         }
 
 
@@ -133,25 +133,25 @@ namespace SofaUnity
         protected void MoveUp()
         {
             newPosition[0] = capsuleOri + this.transform.forward * m_speed;
-            m_sofaCapsuleMesh.SetVertices(newPosition);
+            m_sofaCapsuleMesh.SetPositions(newPosition);
         }
 
         protected void MoveDown()
         {
             newPosition[0] = capsuleOri - this.transform.forward * m_speed;
-            m_sofaCapsuleMesh.SetVertices(newPosition);
+            m_sofaCapsuleMesh.SetPositions(newPosition);
         }
 
         protected void MoveLeft()
         {
             newPosition[0] = capsuleOri + this.transform.right * m_speed;
-            m_sofaCapsuleMesh.SetVertices(newPosition);
+            m_sofaCapsuleMesh.SetPositions(newPosition);
         }
 
         protected void MoveRight()
         {
             newPosition[0] = capsuleOri - this.transform.right * m_speed;
-            m_sofaCapsuleMesh.SetVertices(newPosition);
+            m_sofaCapsuleMesh.SetPositions(newPosition);
         }
 
 

--- a/Core/Scripts/Modules/Controllers/SofaCapsuleController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaCapsuleController.cs
@@ -104,9 +104,9 @@ namespace SofaUnity
         protected void UpdateCapsuleFromSofa()
         {
             int nbrV = m_sofaCapsuleMesh.NbVertices();
-            float[] sofaVertices = m_sofaCapsuleMesh.SofaMeshTopology.m_vertexBuffer;
+            Vector3 sofaVertices = m_sofaCapsuleMesh.GetPosition(0);
 
-            capsuleOri[0] = -sofaVertices[0] * sofaToUnity[0];
+            capsuleOri[0] = sofaVertices[0] * sofaToUnity[0];
             capsuleOri[1] = sofaVertices[1] * sofaToUnity[1];
             capsuleOri[2] = sofaVertices[2] * sofaToUnity[2];
 

--- a/Core/Scripts/Modules/Controllers/SofaCapsuleController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaCapsuleController.cs
@@ -106,10 +106,9 @@ namespace SofaUnity
             int nbrV = m_sofaCapsuleMesh.NbVertices();
             float[] sofaVertices = m_sofaCapsuleMesh.SofaMeshTopology.m_vertexBuffer;
 
-            for (int i = 0; i < 3; i++)
-            {
-                capsuleOri[i] = sofaVertices[i] * sofaToUnity[i];
-            }
+            capsuleOri[0] = -sofaVertices[0] * sofaToUnity[0];
+            capsuleOri[1] = sofaVertices[1] * sofaToUnity[1];
+            capsuleOri[2] = sofaVertices[2] * sofaToUnity[2];
 
             this.transform.position = capsuleOri;
         }

--- a/Core/Scripts/Modules/Controllers/SofaMeshController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaMeshController.cs
@@ -104,7 +104,7 @@ namespace SofaUnity
             {
                 newPosition[i] = transform.TransformPoint(m_unityMesh.mesh.vertices[map[i]]);
             }
-            m_sofaMesh.SetVertices(newPosition);
+            m_sofaMesh.SetPositions(newPosition);
 
             UpdateFromSofa();
         }

--- a/Core/Scripts/Modules/Controllers/SofaObjectController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaObjectController.cs
@@ -119,10 +119,9 @@ namespace SofaUnity
             int nbrV = m_sofaMesh.NbVertices();
             float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
 
-            for (int i = 0; i < 3; i++)
-            {
-                objectOri[i] = sofaVertices[i] * sofaToUnity[i];
-            }
+            objectOri[0] = -sofaVertices[0] * sofaToUnity[0];
+            objectOri[1] = sofaVertices[1] * sofaToUnity[1];
+            objectOri[2] = sofaVertices[2] * sofaToUnity[2];
 
             this.transform.position = objectOri;
         }

--- a/Core/Scripts/Modules/Controllers/SofaObjectController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaObjectController.cs
@@ -117,9 +117,9 @@ namespace SofaUnity
         protected void UpdateFromSofa()
         {
             int nbrV = m_sofaMesh.NbVertices();
-            float[] sofaVertices = m_sofaMesh.SofaMeshTopology.m_vertexBuffer;
+            Vector3 sofaVertices = m_sofaMesh.GetPosition(0);
 
-            objectOri[0] = -sofaVertices[0] * sofaToUnity[0];
+            objectOri[0] = sofaVertices[0] * sofaToUnity[0];
             objectOri[1] = sofaVertices[1] * sofaToUnity[1];
             objectOri[2] = sofaVertices[2] * sofaToUnity[2];
 

--- a/Core/Scripts/Modules/Controllers/SofaObjectController.cs
+++ b/Core/Scripts/Modules/Controllers/SofaObjectController.cs
@@ -181,13 +181,13 @@ namespace SofaUnity
                 newPositionRigid[0] = my_newPosition[0];
                 newPositionRigid[1] = my_newPosition[1];
                 newPositionRigid[2] = my_newPosition[2];
-                m_sofaMesh.SetVelocities(stopVelocityRigid);
-                m_sofaMesh.SetPositions(newPositionRigid);
+                m_sofaMesh.SetRawVelocities(stopVelocityRigid);
+                m_sofaMesh.SetRawPositions(newPositionRigid);
             }
             else
             {
                 m_sofaMesh.SetVelocities(stopVelocity);
-                m_sofaMesh.SetVertices(newPosition);
+                m_sofaMesh.SetPositions(newPosition);
             }
 
             this.transform.position = my_newPosition;

--- a/Core/Scripts/Utils/TextureInterpolationModel.cs
+++ b/Core/Scripts/Utils/TextureInterpolationModel.cs
@@ -107,32 +107,11 @@ namespace SofaUnity
                 if (m_uv == null)
                     m_uv = new Vector2[m_nbrV];
 
-                Vector3[] dataValues = m_meshValues.SofaMeshTopology.m_mesh.vertices;
-
-                //float[] dataValues = m_meshValues.SofaMeshTopology.m_vertexBuffer;
-                //float min = 100.0f;
-                //float max = -100.0f;
-
-                int meshDim = m_meshValues.SofaMeshTopology.m_meshDim;
-
-                //for (int i = 0; i < nbrV; i++)
-                //{
-                //    float val = dataValues[i * meshDim];
-                //    if (val < min)
-                //        min = val;
-
-                //    if (val > max)
-                //        max = val;
-                //}
-
-                //max += 0.01f;
-                //min -= 0.01f;
-
                 float scale = 1 / (m_maxValue - m_minValue);
 
                 for (int i = 0; i < nbrV; i++)
                 {
-                    float val = dataValues[i][0];
+                    float val = m_meshValues.GetPosition(i)[0];
 
                     float tex = (val - m_minValue) * scale;
 

--- a/Core/Scripts/Utils/TextureInterpolationModel.cs
+++ b/Core/Scripts/Utils/TextureInterpolationModel.cs
@@ -107,7 +107,9 @@ namespace SofaUnity
                 if (m_uv == null)
                     m_uv = new Vector2[m_nbrV];
 
-                float[] dataValues = m_meshValues.SofaMeshTopology.m_vertexBuffer;
+                Vector3[] dataValues = m_meshValues.SofaMeshTopology.m_mesh.vertices;
+
+                //float[] dataValues = m_meshValues.SofaMeshTopology.m_vertexBuffer;
                 //float min = 100.0f;
                 //float max = -100.0f;
 
@@ -130,7 +132,7 @@ namespace SofaUnity
 
                 for (int i = 0; i < nbrV; i++)
                 {
-                    float val = dataValues[i* meshDim];
+                    float val = dataValues[i][0];
 
                     float tex = (val - m_minValue) * scale;
 


### PR DESCRIPTION
- All methods inside the xxxMeshAPI class are doing the conversion.
- All methods get Unity mesh.vertices or Vector3 GetPosition returns coordinates in left handed system.
- Add gettter to avoid using raw buffers coming from SOFA
- Update all topology code to draw Triangle, Tetrahedron and Hexahedron in the correct order
- Handle NO_TOPOLOGY case
- Fix tricky cases for particles without mesh or beamModel with edge topology or 1D for heat diffusion